### PR TITLE
Fix ARM64 type mismatch in logging function

### DIFF
--- a/src/rcl.rs
+++ b/src/rcl.rs
@@ -398,7 +398,7 @@ impl MTUnsafeLogFn {
         ret_val_to_err(unsafe { self::rcutils_logging_initialize() })
     }
 
-    pub fn rcutils_logging_logger_is_enabled_for(&self, name: *const i8, severity: i32) -> bool {
+    pub fn rcutils_logging_logger_is_enabled_for(&self, name: *const ::std::os::raw::c_char, severity: i32) -> bool {
         unsafe { self::rcutils_logging_logger_is_enabled_for(name, severity) }
     }
 


### PR DESCRIPTION
This PR fixes a type mismatch issue in `rcutils_logging_logger_is_enabled_for` on ARM64 platforms by casting name to `*const c_char`.
The issue arises because the `c_char` type is platform-dependent and can be either `i8` or `u8`. On ARM64 platforms, `c_char` is `u8`, which causes the type mismatch error during the build process.

Tested on: Linux jammy 5.15.0-69-generic #76-Ubuntu SMP Fri Mar 17 17:25:19 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux