### PR TITLE
Fix errors in tutorial 2.2 Publish and Subscribe

### DIFF
--- a/docs/pubsub.html
+++ b/docs/pubsub.html
@@ -283,7 +283,7 @@ fn main() -&gt; Result&lt;(), DynError&gt; {
     let node = ctx.create_node(&quot;my_talker&quot;, None, Default::default())?;
 
     // Create a publisher.
-    let publisher = node.create_publisher::&lt;std_msgs::msg::String&gt;(&quot;my_topic&quot;, None, true)?;
+    let publisher = node.create_publisher::&lt;std_msgs::msg::String&gt;(&quot;my_topic&quot;, None)?;
 
     // Create a logger.
     let logger = Logger::new(&quot;my_talker&quot;);
@@ -327,7 +327,7 @@ let node = ctx.create_node(&quot;my_talker&quot;, None, Default::default())?;
 <pre><pre class="playground"><code class="language-rust"><span class="boring">#![allow(unused)]
 </span><span class="boring">fn main() {
 </span>// Create a publisher.
-let publisher = node.create_publisher::&lt;std_msgs::msg::String&gt;(&quot;my_topic&quot;, None, true)?;
+let publisher = node.create_publisher::&lt;std_msgs::msg::String&gt;(&quot;my_topic&quot;, None)?;
 <span class="boring">}</span></code></pre></pre>
 <ul>
 <li><code>&lt;std_msgs::msg::String&gt;</code> : the publisher can send values of <code>std_msgs::msg::String</code>.</li>
@@ -450,7 +450,7 @@ fn main() -&gt; Result&lt;(), DynError&gt; {
     let node = ctx.create_node(&quot;my_listener&quot;, None, Default::default())?;
 
     // Create a subscriber.
-    let subscriber = node.create_subscriber::&lt;std_msgs::msg::String&gt;(&quot;my_topic&quot;, None, true)?;
+    let subscriber = node.create_subscriber::&lt;std_msgs::msg::String&gt;(&quot;my_topic&quot;, None)?;
 
     // Create a logger.
     let logger = Logger::new(&quot;my_listener&quot;);
@@ -477,7 +477,7 @@ fn main() -&gt; Result&lt;(), DynError&gt; {
 <pre><pre class="playground"><code class="language-rust"><span class="boring">#![allow(unused)]
 </span><span class="boring">fn main() {
 </span>// Create a subscriber.
-let subscriber = node.create_subscriber::&lt;std_msgs::msg::String&gt;(&quot;my_topic&quot;, None, true)?;
+let subscriber = node.create_subscriber::&lt;std_msgs::msg::String&gt;(&quot;my_topic&quot;, None)?;
 <span class="boring">}</span></code></pre></pre>
 <p>The arguments are as follows.</p>
 <ul>

--- a/mdbook/src/pubsub.md
+++ b/mdbook/src/pubsub.md
@@ -153,7 +153,7 @@ fn main() -> Result<(), DynError> {
     let node = ctx.create_node("my_talker", None, Default::default())?;
 
     // Create a publisher.
-    let publisher = node.create_publisher::<std_msgs::msg::String>("my_topic", None, true)?;
+    let publisher = node.create_publisher::<std_msgs::msg::String>("my_topic", None)?;
 
     // Create a logger.
     let logger = Logger::new("my_talker");
@@ -198,7 +198,7 @@ The arguments indicate as follows.
 
 ```rust
 // Create a publisher.
-let publisher = node.create_publisher::<std_msgs::msg::String>("my_topic", None, true)?;
+let publisher = node.create_publisher::<std_msgs::msg::String>("my_topic", None)?;
 ```
 
 - `<std_msgs::msg::String>` : the publisher can send values of `std_msgs::msg::String`.
@@ -353,7 +353,7 @@ fn main() -> Result<(), DynError> {
     let node = ctx.create_node("my_listener", None, Default::default())?;
 
     // Create a subscriber.
-    let subscriber = node.create_subscriber::<std_msgs::msg::String>("my_topic", None, true)?;
+    let subscriber = node.create_subscriber::<std_msgs::msg::String>("my_topic", None)?;
 
     // Create a logger.
     let logger = Logger::new("my_listener");
@@ -383,7 +383,7 @@ Similar to the publisher,
 
 ```rust
 // Create a subscriber.
-let subscriber = node.create_subscriber::<std_msgs::msg::String>("my_topic", None, true)?;
+let subscriber = node.create_subscriber::<std_msgs::msg::String>("my_topic", None)?;
 ```
 
 The arguments are as follows.


### PR DESCRIPTION
Dear developer,

Thanks for creating and open-sourcing such a good repo. 
I found some small errors in Tutorial 2.2: Publish and Subscribe, where creating a publisher or subscriber from a node only takes in 2 parameters while in the tutorial you passed 3. I removed the redundant `true` parameter in the HTML and the markdown file.

Best,
Levi