### PR TITLE
Improve ROS_DISTRO handling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,16 +51,24 @@ fn main() {
         }
     }
 
-    if let Some(e) = std::env::var_os("ROS_DISTRO") {
-        match e.to_str().unwrap() {
-            "iron" => {
-                println!("cargo:rustc-link-lib=service_msgs__rosidl_typesupport_c");
-                println!("cargo:rustc-link-lib=service_msgs__rosidl_generator_c");
-                println!("cargo:rustc-cfg=feature=\"iron\"");
-            }
-            "humble" => println!("cargo:rustc-cfg=feature=\"humble\""),
-            "galactic" => println!("cargo:rustc-cfg=feature=\"galactic\""),
-            _ => (),
+    println!("cargo:rerun-if-env-changed=ROS_DISTRO");
+    let distro_name = std::env::var_os("ROS_DISTRO");
+    match &*distro_name.and_then(|v| v.into_string().ok()).unwrap_or("".to_string()) {
+        "iron" => {
+            println!("cargo:rustc-link-lib=service_msgs__rosidl_typesupport_c");
+            println!("cargo:rustc-link-lib=service_msgs__rosidl_generator_c");
+            println!("cargo:rustc-cfg=feature=\"iron\"");
         }
+        "humble" => println!("cargo:rustc-cfg=feature=\"humble\""),
+        "galactic" => println!("cargo:rustc-cfg=feature=\"galactic\""),
+
+        _ => {
+            let default = "iron";
+
+            println!("cargo:warning='ROS_DISTRO is not set properly. Defaulting to {default}.'");
+            println!("cargo:rustc-link-lib=service_msgs__rosidl_typesupport_c");
+            println!("cargo:rustc-link-lib=service_msgs__rosidl_generator_c");
+            println!("cargo:rustc-cfg=feature=\"{default}\"");
+        },
     }
 }


### PR DESCRIPTION
In order to avoid build errors that are difficult to read. Add some checks prior to building.
- check if ROS_DISTRO is properly set
- see if ROS_DISTRO is the same as that in previously succeeded build