### PR TITLE
remove usage of is_some_and: stable starting from 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_drive"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = [ "Yuuki Takano <yuuki.takano@tier4.jp>, TIER IV, Inc.", "Seio Inoue" ]
 description = "safe_drive: Formally Specified Rust Bindings for ROS2"

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1559,27 +1559,32 @@ fn notify_action_client(
                 && handler
                     .feedback_handler
                     .clone()
-                    .is_some_and(|h| (h.borrow_mut())() == CallbackResult::Remove))
+                    .map(|h| (h.borrow_mut())() == CallbackResult::Remove)
+                    .unwrap_or(false))
                 || (is_status_ready
                     && handler
                         .status_handler
                         .clone()
-                        .is_some_and(|h| (h.borrow_mut())() == CallbackResult::Remove))
+                        .map(|h| (h.borrow_mut())() == CallbackResult::Remove)
+                        .unwrap_or(false))
                 || (is_goal_response_ready
                     && handler
                         .goal_handler
                         .clone()
-                        .is_some_and(|h| (h.borrow_mut())() == CallbackResult::Remove))
+                        .map(|h| (h.borrow_mut())() == CallbackResult::Remove)
+                        .unwrap_or(false))
                 || (is_cancel_response_ready
                     && handler
                         .cancel_goal_handler
                         .clone()
-                        .is_some_and(|h| (h.borrow_mut())() == CallbackResult::Remove))
+                        .map(|h| (h.borrow_mut())() == CallbackResult::Remove)
+                        .unwrap_or(false))
                 || (is_result_response_ready
                     && handler
                         .result_handler
                         .clone()
-                        .is_some_and(|h| (h.borrow_mut())() == CallbackResult::Remove))
+                        .map(|h| (h.borrow_mut())() == CallbackResult::Remove)
+                        .unwrap_or(false))
             {
                 Ok(None)
             } else {


### PR DESCRIPTION
`is_some_and` is stable since 1.70.0 so when using rustc installed by apt-get the package is not compilable anymore 