### PR TITLE
Fixed error string cast

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -147,7 +147,7 @@ impl From<RCLActionError> for u32 {
 impl std::fmt::Display for rcl::rcutils_error_string_t {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = self.str_;
-        let inner: &[u8] = unsafe { &*(&s as *const [i8] as *const [u8]) };
+        let inner: &[u8] = unsafe { std::slice::from_raw_parts(s.as_ptr() as *const u8, s.len()) };
         let s = String::from_utf8(inner.to_vec()).unwrap();
         write!(f, "{}", s)
     }


### PR DESCRIPTION
`self.str_;` is supposed as `&[i8]`, but  `str_` in `rcutils_error_string_t` could be `[u8; 1024]` in some case.

In my environment, I got compilation error in Docker environment on MacOS.

I think this code could be either `&[i8]` and `&[u8]`, so please check it.

