### PR TITLE
Fix the issue preventing compilation on aarch64 Linux.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -77,7 +77,7 @@ impl Context {
             // initialize context
             guard.rcl_init(
                 CARGS.len() as i32,
-                CARGS.as_ptr() as *const *const i8,
+                CARGS.as_ptr() as *const *const ::std::os::raw::c_char,
                 options.as_ptr(),
                 &mut context,
             )?;


### PR DESCRIPTION
The type of the second argument of `rcl_node_init()` is `*const ::std::os::raw::c_char`, but a value of type `*const *const i8` is being assigned when calling it. While `std::os::raw::c_char` is i8 on amd64 Linux, it is u8 on aarch64 Linux, causing a compilation error on aarch64 Linux.

This issue has been fixed.

The test results are shown below.

```
running 51 tests
test src/context.rs - context::Context::new (line 53) ... ok
test src/context.rs - context::Context::create_selector (line 138) ... ok
test src/context.rs - context::Context::create_node (line 102) ... ok
test src/context.rs - context (line 6) ... ok
test src/logger.rs - logger (line 49) ... ok
test src/logger.rs - logger (line 22) ... ok
test src/logger.rs - logger (line 7) ... ok
test src/lib.rs - (line 59) ... ok
test src/node.rs - node (line 6) ... ok
test src/node.rs - node::Node::create_client (line 234) ... ok
test src/node.rs - node::Node::create_publisher (line 112) ... ok
test src/node.rs - node::Node::create_publisher_disable_loaned_message (line 138) ... ok
test src/node.rs - node::Node::create_server (line 210) ... ok
test src/node.rs - node::Node::create_subscriber (line 162) ... ok
test src/node.rs - node::Node::create_subscriber_disable_loaned_message (line 186) ... ok
test src/lib.rs - (line 133) ... ok
test src/parameter.rs - parameter::FloatingPointRange (line 316) ... ok
test src/parameter.rs - parameter (line 7) ... ok
test src/parameter.rs - parameter (line 86) ... ok
test src/parameter.rs - parameter::IntegerRange (line 274) ... ok
test src/parameter.rs - parameter::Parameters (line 372) ... ok
test src/selector.rs - selector::Selector::add_action_server (line 575) ... ignored
test src/parameter.rs - parameter::ParameterServer (line 211) ... ok
test src/selector.rs - selector::Selector (line 183) ... ok
test src/selector.rs - selector::Selector::add_server (line 446) ... ok
test src/selector.rs - selector::Selector::add_timer (line 931) ... ok
test src/selector.rs - selector::Selector::add_subscriber (line 317) ... ok
test src/selector.rs - selector::Selector::add_wall_timer (line 965) ... ok
test src/selector.rs - selector::Selector::wait (line 1105) ... ok
test src/selector.rs - selector (line 7) ... ok
test src/selector.rs - selector::Selector::wait_timeout (line 1055) ... ok
test src/service/client.rs - service::client::Client<T>::send (line 134) ... ok
test src/service/client.rs - service::client::Client<T>::send_ret_seq (line 179) ... ok
test src/service/client.rs - service::client::ClientRecv<T>::recv (line 290) ... ok
test src/service/client.rs - service::client::ClientRecv<T>::recv_timeout (line 336) ... ok
test src/service/server.rs - service::server (line 47) ... ok
test src/service/server.rs - service::server (line 7) ... ok
test src/service/server.rs - service::server::Server<T>::recv (line 247) ... ok
test src/service/client.rs - service::client (line 8) ... ok
test src/service/server.rs - service::server::Server<T>::try_recv (line 180) ... ok
test src/service/server.rs - service::server::ServerSend<T>::send (line 313) ... ok
test src/topic/publisher.rs - topic::publisher (line 30) ... ok
test src/topic/publisher.rs - topic::publisher (line 9) ... ok
test src/topic/publisher.rs - topic::publisher::Publisher (line 71) ... ok
test src/topic/publisher.rs - topic::publisher::Publisher<T>::send (line 187) ... ok
test src/topic/subscriber.rs - topic::subscriber (line 109) ... ok
test src/topic/subscriber.rs - topic::subscriber (line 130) ... ok
test src/topic/subscriber.rs - topic::subscriber (line 18) ... ok
test src/topic/subscriber.rs - topic::subscriber::Subscriber<T>::recv (line 367) ... ok
test src/topic/subscriber.rs - topic::subscriber::Subscriber<T>::try_recv (line 313) ... ok
test src/topic/subscriber.rs - topic::subscriber (line 56) ... ok

test result: ok. 50 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 9.75s
```