### PR TITLE
feat: add a send_raw for publisher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_drive"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["Yuuki Takano <yuuki.takano@tier4.jp>, TIER IV, Inc.", "Seio Inoue"]
 description = "safe_drive: Formally Specified Rust Bindings for ROS2"

--- a/src/rcl.rs
+++ b/src/rcl.rs
@@ -982,6 +982,22 @@ impl MTSafeFn {
         })
     }
 
+    pub fn rcl_publish_serialized_message(
+        publisher: *const rcl_publisher_t,
+        data: &[u8],
+        allocation: *mut rmw_publisher_allocation_t,
+    ) -> RCLResult<()> {
+        let ros_message = rcl_serialized_message_t {
+            buffer: data.as_ptr() as *mut u8,
+            buffer_length: data.len(),
+            buffer_capacity: data.len(),
+            allocator: unsafe { self::rcutils_get_default_allocator() }
+        };
+        ret_val_to_err(unsafe {
+            self::rcl_publish_serialized_message(publisher, (&ros_message) as *const _, allocation)
+        })
+    }
+
     pub fn rmw_get_default_publisher_options() -> rmw_publisher_options_t {
         unsafe { self::rmw_get_default_publisher_options() }
     }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1118,7 +1118,9 @@ impl Selector {
 
             // set services
             for (_, h) in self.services.iter() {
-                let service = h.event.lock();
+                let Some(service) = h.event.try_lock() else {
+                    continue;
+                };
                 guard.rcl_wait_set_add_service(&mut self.wait_set, &service.service, null_mut())?;
             }
 

--- a/src/selector/async_selector.rs
+++ b/src/selector/async_selector.rs
@@ -167,34 +167,36 @@ fn select(
             }
         }
 
-        if let Err(_e) = selector.wait() {
-            if signal_handler::is_halt() {
-                for (_, h) in selector.subscriptions.iter_mut() {
-                    if let Some(handler) = &mut h.handler {
-                        (*handler)();
-                    }
+        if selector
+            .wait()
+            .is_err()
+            && signal_handler::is_halt()
+        {
+            for (_, h) in selector.subscriptions.iter_mut() {
+                if let Some(handler) = &mut h.handler {
+                    (*handler)();
                 }
-
-                for (_, h) in selector.services.iter_mut() {
-                    if let Some(handler) = &mut h.handler {
-                        (*handler)();
-                    }
-                }
-
-                for (_, h) in selector.clients.iter_mut() {
-                    if let Some(handler) = &mut h.handler {
-                        (*handler)();
-                    }
-                }
-
-                for (_, h) in selector.cond.iter_mut() {
-                    if let Some(handler) = &mut h.handler {
-                        (*handler)();
-                    }
-                }
-
-                return Ok(());
             }
+
+            for (_, h) in selector.services.iter_mut() {
+                if let Some(handler) = &mut h.handler {
+                    (*handler)();
+                }
+            }
+
+            for (_, h) in selector.clients.iter_mut() {
+                if let Some(handler) = &mut h.handler {
+                    (*handler)();
+                }
+            }
+
+            for (_, h) in selector.cond.iter_mut() {
+                if let Some(handler) = &mut h.handler {
+                    (*handler)();
+                }
+            }
+
+            return Ok(());
         }
     }
 }


### PR DESCRIPTION
## First commit
Adding new method for publisher to send raw data

- This is useful when we read an mcap for example and need to replay without CDR serde
- The new method is `unsafe` as we don't know if the cdr serialization is done correctly by the user or not

## Second commit
Faced a dead lock issue and after some debugging looks like issue is due to circular dependency for ServerData mutex
Please review it carefully may be I missed something